### PR TITLE
dep bumps + fix test ouput

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+const console = require('console');
 const Botkit = require('botkit');
 
 // add new commands below
@@ -17,9 +18,9 @@ exports.start = function start(token) {
     retry: 3,
   }).startRTM((err, bot, payload) => {
     if (err) {
-      console.error(err); // eslint-disable-line no-console
+      console.error(err);
     } else {
-      console.dir(payload); // eslint-disable-line no-console
+      console.dir(payload);
     }
   });
 };

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -2,6 +2,8 @@
 
 const mockStartRTM = jest.fn();
 
+jest.mock('console');
+
 jest.mock('botkit', () => ({
   slackbot: () => ({
     hears: () => {},

--- a/main.js
+++ b/main.js
@@ -1,8 +1,9 @@
+const console = require('console');
 const lib = require('./lib');
 
 // SLACK_RTM_TOKEN: Slack Real Time Messaging Token
 if (!process.env.SLACK_RTM_TOKEN) {
-  console.error('Specify SLACK_RTM_TOKEN in environment'); // eslint-disable-line no-console
+  console.error('Specify SLACK_RTM_TOKEN in environment');
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "eslint": "3.6.1",
     "eslint-config-airbnb-base": "8.0.0",
     "eslint-plugin-import": "1.16.0",
-    "jest": "15.1.1",
-    "sinon": "1.17.6"
+    "jest": "15.1.1"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
   },
   "homepage": "https://github.com/spbk/data#readme",
   "devDependencies": {
-    "eslint": "3.6.0",
-    "eslint-config-airbnb-base": "7.1.0",
+    "eslint": "3.6.1",
+    "eslint-config-airbnb-base": "8.0.0",
     "eslint-plugin-import": "1.16.0",
-    "jest": "15.1.1"
+    "jest": "15.1.1",
+    "sinon": "1.17.6"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
gets all the greenkeeper updates and makes the test output cleaner by mocking `console` statements (no scary errors)